### PR TITLE
Add calendar page as a replacement for calendar.overte.org

### DIFF
--- a/source/calendar.rst
+++ b/source/calendar.rst
@@ -1,0 +1,27 @@
+########
+Calendar
+########
+
+There is a multitude of regular and irregular events that happen in Overte.
+This calendar aims to give you an overview of such events.
+Please note that all times listed here are UTC.
+To convert to your local timezone, please ask your preferred search engine something along the lines of: "What is Saturday 19:00 UTC in my time?"
+
++--------------------------+
+| Monday                   |
++==========================+
+| 20:00 UTC  Maker Monday  |
++--------------------------+
+
++---------------------------------+
+| Wednesday                       |
++=================================+
+| 20:15 UTC  Wednesday game night |
++---------------------------------+
+
++-------------------------------+
+| Saturday                      |
++===============================+
+| 19:00 UTC  Development meetup |
++-------------------------------+
+

--- a/source/index.rst
+++ b/source/index.rst
@@ -51,7 +51,7 @@ If you would like to help translate this website or other parts of Overte, head 
     :hidden:
 
     Home <self>
-    Events 🔗 <https://calendar.overte.org>
+    Calendar <calendar>
     Downloads <downloads>
     Gallery <gallery>
     Contact <contact>


### PR DESCRIPTION
calendar.overte.org is currently the only piece of software remaining on a 35 $/m VPS. Since the timezone conversion doesn't work anymore, it seems preferable to just use a static page instead.