### PR TITLE
Remove myst-parser dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,5 @@ sphinx-intl>=2.0.1
 sphinx-rtd-theme>=0.5.2
 sphinx-design>=0.3.0
 
-#Because of a bug in myst-parser, we require a version *before* 0.17.0. See https://github.com/executablebooks/MyST-Parser/issues/519#issuecomment-1044450711
-myst-parser>=0.14.0, <0.17.0
-
-# myst-parser < 0.17.2 requires attrs but the package doesn't depend on it.
-attrs
-
 # Utility for easily running builds in Python virtual environments.
 venv-run

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Overte'
-copyright = '2022-2023, Overte e.V.'
+copyright = '2022-2024, Overte e.V.'
 author = 'Julian Groß'
 
 # The short X.Y version
@@ -39,7 +39,7 @@ needs_sphinx = '3.5.4'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'myst_parser', 'sphinx_design'
+    'sphinx_design'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Remove myst-parser dependency. This removes markdown support, which we don't currently use.