### PR TITLE
Add note about minimum required AppImageLauncher version.

### DIFF
--- a/source/downloads.rst
+++ b/source/downloads.rst
@@ -17,6 +17,10 @@ Linux
 Interface
 *********
 
+.. warning::
+
+    If you are using AppImageLauncher make sure you are using version 3.0.0-alpha-3 or later, otherwise the AppImage will fail to start, even from command line.
+
 .. button-link:: https://public.overte.org/build/overte/release/2025.09.1/Overte-2025.09.1-x86_64.AppImage
     :shadow:
     :color: primary


### PR DESCRIPTION
The [new AppImages created on the Conan branch](https://github.com/overte-org/overte/pull/1427) use the new static AppImage runtime, which apparently breaks on current stable version of AppImageLauncher (See https://github.com/TheAssassin/AppImageLauncher/issues/585).
This PR adds a warning to our downloads page about this issue, as there is no proper error message indicating the AppImageLauncher could have caused a problem.