### PR TITLE
Update donation links.

### DIFF
--- a/source/donate.rst
+++ b/source/donate.rst
@@ -9,10 +9,9 @@ If you would like to support Overte and its development, consider donating.
 
 You may donate via the following methods in order of preference:
 
-- `OpenCollective 🔗 <https://opencollective.com/overte>`_ – Debit card, Credit card, SEPA Direct Debit
-- `Stripe 🔗 <https://donate.stripe.com/28o8xXbZC9uS7RecMM>`_ – Almost any payment method you can think of
+- `OpenCollective 🔗 <https://opencollective.com/overte>`_ – Debit card, Credit card, SEPA Direct Debit, Bancontact
 - Bank transfer – Recipient: Overte e.V., IBAN: DE18 4306 0967 1303 3311 00, BIC: GENODEM1GLS, Account number 1303331100
-- SEPA Direct Debit – Send a filled out `mandate <https://overte.org/_static/resources/SEPA_Basis_Lastschriftmandat_beschreibbar.pdf>`_ to accounting@overte.org or our postal adress together with how much you would like to contribute.
+- SEPA Direct Debit – Send a filled out `mandate <https://overte.org/_static/resources/SEPA_Basis_Lastschriftmandat_beschreibbar.pdf>`_ to accounting@overte.org or our postal address together with how much you would like to contribute.
 - `PayPal 🔗 <https://www.paypal.com/donate/?hosted_button_id=GJPDZP47RG34E>`_
 
 .. note::


### PR DESCRIPTION
Directly using Stripe was removed, as it is apparently too unsafe for us, especially considering that we received less than 3€ of donations through that channel.
OpenCollective now supports Bancontact and an unknown list of more payment options which sometimes show up and sometimes don't. 

OpenCollective is using Stripe for pretty much everything, which I don't exactly like. (For one because there is money just missing from our Stripe account right now, but also because of lock-in and the higher fees compared to the competition. For credit card payments they charge 50-100% higher fees than German banks for example.)