### PR TITLE
Redesign the downloads page.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Sphinx>=3.5.4, <9.0.0
 sphinx-intl>=2.0.1
 sphinx-rtd-theme>=3.0.2
 sphinx-design>=0.3.0
+sphinx-tabs
 ablog
 sphinxcontrib-video>=0.4.2
 

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -432,6 +432,10 @@ pre span {
     --sd-color-primary-highlight: #515394;
 }
 
+.download-icon-style {
+    font-size: 3em; /* Increase size of FontAwesome icons on the downloads page. */
+}
+
 /***********************************/
 /************* ABlog ***************/
 /***********************************/

--- a/source/conf.py
+++ b/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx_design',
     'ablog',
     'sphinx.ext.intersphinx',  # Required by ABlog.
+    'sphinx_tabs.tabs',
     'sphinxcontrib.video',  # Used for embedding videos.
 ]
 
@@ -83,6 +84,9 @@ smartquotes_excludes = {'languages': ['fr'], 'builders': ['html']}
 
 # Force us to provide both webm and mp4 videos. MacOS/iOS does not support free codecs, so we always provide mp4 alternatives.
 video_enforce_extra_source = True
+
+# Use Sphinx Tabs for the linkcheck builder in addition to the HTML builder.
+sphinx_tabs_valid_builders = ['linkcheck']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/source/downloads.rst
+++ b/source/downloads.rst
@@ -10,11 +10,11 @@ Take a look at the changelog on GitHub: `Changelog 🔗 <https://github.com/over
 
 .. tabs::
 
-   .. tab:: Linux :fa:`linux;download-icon-style`
+   .. tab:: :fa:`linux;download-icon-style` Linux
 
         .. tabs::
 
-            .. tab:: Interface (Client) :octicon:`device-desktop;0.9em;`
+            .. tab:: :octicon:`device-desktop;0.9em;` Interface (Client)
 
                 .. warning::
 
@@ -37,14 +37,14 @@ Take a look at the changelog on GitHub: `Changelog 🔗 <https://github.com/over
                     You will need to set the AppImage as **executable** using your file manager,
                     or a command like: :bash:`chmod +x Overte.AppImage`.
 
-            .. tab:: Domain Server :octicon:`server;0.9em;`
+            .. tab:: :octicon:`server;0.9em;` Domain Server
 
                 Select the appropriate package for your distribution and architecture from `public.overte.org 🔗 <https://public.overte.org/index.html#build/overte/release/2026.04.1/>`_.
 
                 There are also Docker images available on `hub.docker.com 🔗 <https://hub.docker.com/r/overte/overte-server/tags>`_. These images are still new, so please report any issues you run into on our `GitHub issue tracker 🔗 <https://github.com/overte-org/overte/issues>`_.
 
 
-   .. tab:: Windows :fa:`windows;download-icon-style`
+   .. tab:: :fa:`windows;download-icon-style` Windows
 
         .. card::
 
@@ -64,7 +64,7 @@ Take a look at the changelog on GitHub: `Changelog 🔗 <https://github.com/over
                 To run it anyway click on "**More info**" and then "**Run anyway**".
 
 
-   .. tab:: Source :fa:`code-fork;download-icon-style`
+   .. tab:: :fa:`code-fork;download-icon-style` Source
 
         .. card::
 

--- a/source/downloads.rst
+++ b/source/downloads.rst
@@ -8,67 +8,65 @@ The current release of Overte is version 2026.04.1.
 
 Take a look at the changelog on GitHub: `Changelog 🔗 <https://github.com/overte-org/overte/blob/master/CHANGELOG.md>`_
 
+.. tabs::
 
------
-Linux
------
+   .. tab:: Linux :fa:`linux;download-icon-style`
 
-*********
-Interface
-*********
+        .. tabs::
 
-.. warning::
+            .. tab:: Interface (Client) :octicon:`device-desktop;0.9em;`
 
-    If you are using AppImageLauncher make sure you are using version 3.0.0-alpha-3 or later, otherwise the AppImage will fail to start, even from command line.
+                .. warning::
 
-.. button-link:: https://public.overte.org/build/overte/release/2026.04.1/Overte-2026.04.1-x86_64.AppImage
-    :shadow:
-    :color: primary
+                    If you are using AppImageLauncher make sure you are using version 3.0.0-alpha-3 or later, otherwise the AppImage will fail to start, even from command line.
 
-        Linux AppImage for amd64/x86_64 :octicon:`desktop-download;0.9em;`
+                .. button-link:: https://public.overte.org/build/overte/release/2026.04.1/Overte-2026.04.1-x86_64.AppImage
+                    :shadow:
+                    :color: primary
 
-`Linux AppImage for aarch64 <https://public.overte.org/build/overte/release/2026.04.1/Overte-2026.04.1-aarch64.AppImage>`_ :octicon:`desktop-download;0.9em;`
+                        Linux AppImage for amd64/x86_64 :octicon:`desktop-download;0.9em;`
 
-.. note::
+                .. button-link:: https://public.overte.org/build/overte/release/2026.04.1/Overte-2026.04.1-aarch64.AppImage
+                    :shadow:
+                    :color: muted
 
-    You will need to set the AppImage as **executable** using your file manager,
-    or a command like: :bash:`chmod +x Overte.AppImage`.
+                        Linux AppImage for aarch64 :octicon:`desktop-download;0.9em;`
 
+                .. note::
 
-*************
-Domain Server
-*************
+                    You will need to set the AppImage as **executable** using your file manager,
+                    or a command like: :bash:`chmod +x Overte.AppImage`.
 
-Select the appropriate package for your distribution and architecture from `public.overte.org 🔗 <https://public.overte.org/index.html#build/overte/release/2026.04.1/>`_.
+            .. tab:: Domain Server :octicon:`server;0.9em;`
 
-There are also Docker images available on `hub.docker.com 🔗 <https://hub.docker.com/r/overte/overte-server/tags>`_. These images are still new, so please report any issues you run into on our `GitHub issue tracker 🔗 <https://github.com/overte-org/overte/issues>`_.
+                Select the appropriate package for your distribution and architecture from `public.overte.org 🔗 <https://public.overte.org/index.html#build/overte/release/2026.04.1/>`_.
 
-
--------
-Windows
--------
-
-The Windows installer contains both Interface and the Domain Server.
-Select a custom install and tick “Overte Server” during the installation process if you want to run a Domain Server.
-You can always rerun the installer later to install the server software afterwards.
-
-.. button-link:: https://public.overte.org/build/overte/release/2026.04.1/Overte-2026.04.1.exe
-    :shadow:
-    :color: primary
-
-        Windows Installer for x86_64 :octicon:`desktop-download;0.9em;`
-
-.. note::
-
-    Windows Defender might display a warning about the Windows installer being potentially unsafe.
-    To run it anyway click on "**More info**" and then "**Run anyway**".
+                There are also Docker images available on `hub.docker.com 🔗 <https://hub.docker.com/r/overte/overte-server/tags>`_. These images are still new, so please report any issues you run into on our `GitHub issue tracker 🔗 <https://github.com/overte-org/overte/issues>`_.
 
 
-.. _reference_to_downloads_source:
+   .. tab:: Windows :fa:`windows;download-icon-style`
 
-------
-Source
-------
+        .. card::
 
-Our source code is available on `our GitHub repository 🔗 <https://github.com/overte-org/overte/>`_.
-If you intend to build from source, we would suggest building the master branch directly instead of a release, to profit from the latest improvements.
+            The Windows installer contains both Interface and the Domain Server.
+            Select a custom install and tick “Overte Server” during the installation process if you want to run a Domain Server.
+            You can always rerun the installer later to install the server software afterwards.
+
+            .. button-link:: https://public.overte.org/build/overte/release/2026.04.1/Overte-2026.04.1.exe
+                :shadow:
+                :color: primary
+
+                    Windows Installer for x86_64 :octicon:`desktop-download;0.9em;`
+
+            .. note::
+
+                Windows Defender might display a warning about the Windows installer being potentially unsafe.
+                To run it anyway click on "**More info**" and then "**Run anyway**".
+
+
+   .. tab:: Source :fa:`code-fork;download-icon-style`
+
+        .. card::
+
+            Our source code is available on `our GitHub repository 🔗 <https://github.com/overte-org/overte/>`_.
+            If you intend to build from source, we would suggest building the master branch directly instead of a release, to profit from the latest improvements.

--- a/source/index.rst
+++ b/source/index.rst
@@ -4,7 +4,7 @@
 About
 #####
 
-Overte is an :ref:`open source<reference_to_downloads_source>` virtual worlds and social VR software which enables you to create and share virtual worlds as virtual reality (VR) and desktop experiences. You can create and host your own virtual world,
+Overte is an `open source 🔗 <https://github.com/overte-org/overte>`_ virtual worlds and social VR software which enables you to create and share virtual worlds as virtual reality (VR) and desktop experiences. You can create and host your own virtual world,
 explore other worlds, meet and connect with other users, attend or host live VR events, and much more.
 
 The Overte software provides the following key features:


### PR DESCRIPTION
- Changed the Linux aarch64 download link to a button with "muted" color.
- Put Linux, Windows, and source, and Interface and the Domain server into separate tabs, to reduce visual noise.

I am still not really satisfied with it, but a lot of these Sphinx extensions are quite limited in what they can do.
I think it will look a little better once we have macOS and Android on there.

https://overte-website-sphinx--65.org.readthedocs.build/en/65/downloads.html