### PR TITLE
Remove Everyday Mindfulness from event calendar

### DIFF
--- a/source/calendar.rst
+++ b/source/calendar.rst
@@ -24,9 +24,3 @@ To convert to your local timezone, please ask your preferred search engine somet
 +================================================================================+
 | 12:00 UTC  Overte Warmup (Starts at 12:00 in VRChat, moves to Overte at 12:30) |
 +--------------------------------------------------------------------------------+
-
-+-----------------------------------+
-| Sunday-Friday                     |
-+===================================+
-| 17:30 UTC  Everyday Mindfulness   |
-+-----------------------------------+


### PR DESCRIPTION
I decided to discontinue the event due to a lack of interest in the community.